### PR TITLE
Fix InputOption class path

### DIFF
--- a/Console/RunAuditCommand.php
+++ b/Console/RunAuditCommand.php
@@ -1,7 +1,7 @@
 <?php
 namespace Crealoz\EasyAudit\Console;
 
-use Composer\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputOption;
 use Crealoz\EasyAudit\Model\AuditStorage;
 use Magento\Framework\Exception\FileSystemException;
 use Symfony\Component\Console\Command\Command;


### PR DESCRIPTION
Hello @ChristopheFerreboeuf 

I was unable to install the module because of a minor issue: `Class "Composer\Console\Input\InputOption" not found#0`

I fixed it.

