### PR TITLE
Fix Proxy class path

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -161,7 +161,7 @@
     <type name="Crealoz\EasyAudit\Service\ModuleTools">
         <arguments>
             <argument name="driver" xsi:type="object">Magento\Framework\Filesystem\Driver\File\Proxy</argument>
-            <argument name="modulelPath" xsi:type="object">Crealoz\EasyAudit\Service\FileSystem\ModulePath\Proxy</argument>
+            <argument name="modulelPath" xsi:type="object">Crealoz\EasyAudit\Service\FileSystem\ModulePaths\Proxy</argument>
         </arguments>
     </type>
     <type name="Crealoz\EasyAudit\Processor\Files\Logic\Modules\CheckEnabled">


### PR DESCRIPTION
Hello @ChristopheFerreboeuf 

I had another problem when compiling the code: `Invalid proxy class for Crealoz\EasyAudit\Service\FileSystem\ModulePath`.

I fixed it.