### PR TITLE
Add Elvis operator to prevent runtime exception

### DIFF
--- a/Processor/Files/Di/Plugins.php
+++ b/Processor/Files/Di/Plugins.php
@@ -217,7 +217,7 @@ class Plugins extends AbstractXmlProcessor implements FileProcessorInterface
     {
         $pluggingClassParts = explode('\\', $pluggingClass);
         $pluggedInClassParts = explode('\\', $pluggedInClass);
-        if ($pluggingClassParts[0].'\\'.$pluggingClassParts[1] === $pluggedInClassParts[0].'\\'.$pluggedInClassParts[1]) {
+        if ($pluggingClassParts[0]?:''.'\\'.$pluggingClassParts[1]?:'' === $pluggedInClassParts[0]?:''.'\\'.$pluggedInClassParts[1]?:'') {
             throw new SameModulePluginException(
                 __("Plugin class must not be in the same module as the plugged in class"),
                 $pluggingClass


### PR DESCRIPTION
# Description

- [x] Bug fix

Magento 2 allows the definition of plugins like the following:

```php
    <type name="Dummy">
        <plugin name="dummy_plugin_on_non_existent_type"
                type="Vendor\Extension\Plugin\MyPluginClass"/>
    </type>
```

It isn't usual or best practice, but it can happen; in this case, the execution termìnates with an "Undefined array key" runtime error.

***Describe the changes you made.***

We prevent the runtime error by adding the Elvis operator `?:''` when accessing unexisting array values.